### PR TITLE
Constructor refactor. Disallowed DateraApi imports

### DIFF
--- a/src/dfs_sdk/api.py
+++ b/src/dfs_sdk/api.py
@@ -18,7 +18,7 @@ DEFAULT_API_VERSION = "v2.1"
 # different api versions with little to no difference in this class
 def _api_getter(base):
 
-    class Base(base):
+    class _DateraBaseApi(base):
         """
         Use this object to talk to the REST interface of a Datera cluster
         """
@@ -59,7 +59,7 @@ def _api_getter(base):
                     name=username, password=password)
 
             # Initialize sub-endpoints:
-            super(Base, self).__init__(self._context, None)
+            super(_DateraBaseApi, self).__init__(self._context, None)
 
         def _create_context(self, hostname, username=None, password=None,
                             tenant=None, timeout=None, secure=True,
@@ -92,7 +92,7 @@ def _api_getter(base):
             """
             return ApiConnection(context)
 
-    return Base
+    return _DateraBaseApi
 
 
 class DateraApi(_api_getter(RootEp2)):

--- a/src/dfs_sdk/base.py
+++ b/src/dfs_sdk/base.py
@@ -83,6 +83,7 @@ class Entity(collections.Mapping):
 
     ######
 
+    # TODO(mss): Allow passing string, then determine the endpoint version
     def _set_subendpoint(self, klass):
         """ Create a sub-endpoint of the given endpoint type """
         assert(issubclass(klass, Endpoint))
@@ -152,6 +153,7 @@ class Endpoint(object):
         else:
             return repr(self)
 
+    # TODO(mss): Allow passing string, then determine the endpoint version
     def _set_subendpoint(self, klass):
         """ Create a sub-endpoint of the given endpoint type """
         assert(issubclass(klass, Endpoint))

--- a/src/dfs_sdk/constants.py
+++ b/src/dfs_sdk/constants.py
@@ -1,9 +1,10 @@
 """
-Provides hard-coded values used in this package
+Provides hard-coded values used in this package.  No imports are allowed
+since many other modules import this one
 """
 __copyright__ = "Copyright 2017, Datera, Inc."
 
-VERSION = "1.1.2"
+VERSION = "1.2.0"
 
 VERSION_HISTORY = """
 Version History:
@@ -13,6 +14,8 @@ Version History:
     1.1.2 -- User, Event_system, Internal, Alerts Endpoints/Entities
     1.2.0 -- v2.2 support, API module refactor
 """
+
+API_VERSIONS = ["v2", "v2.1", "v2.2"]
 
 REST_PORT = 7717
 REST_PORT_HTTPS = 7718

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,11 +2,10 @@ import pytest
 
 
 def test_import():
-
-    from dfs_sdk import DateraApi
+    from dfs_sdk import get_api
 
 
 def test_failed_import():
-
+    # We don't allow importing the direct classes
     with pytest.raises(ImportError):
-        from dfs_sdk import NotDateraApi
+        from dfs_sdk import DateraApi


### PR DESCRIPTION
- Changed the expected way to get a DateraApi object from importing it
  directly to forcing use of the get_api constructor function.
- Updated tests to reflect above change
- Incremented missed version number
- Added some TODO comments
- Added API_VERSIONS constant
- Renamed Base to _DateraBaseApi for clarity reasons