### PR TITLE
Moving common utility functions out to sdk module

### DIFF
--- a/src/dfs_sdk/scaffold.py
+++ b/src/dfs_sdk/scaffold.py
@@ -1,0 +1,38 @@
+from __future__ import (print_function, unicode_literals, division,
+                        absolute_import)
+
+import io
+import re
+
+from dfs_sdk import get_api
+
+IPRE_STR = r'(\d{1,3}\.){3}\d{1,3}'
+IPRE = re.compile(IPRE_STR)
+
+SIP = re.compile(r'san_ip\s+?=\s+?(?P<san_ip>%s)' % IPRE_STR)
+SLG = re.compile(r'san_login\s+?=\s+?(?P<san_login>.*)')
+SPW = re.compile(r'san_password\s+?=\s+?(?P<san_password>.*)')
+
+
+def readCinderConf():
+    data = None
+    with io.open('/etc/cinder/cinder.conf') as f:
+        data = f.read()
+    san_ip = SIP.search(data).group('san_ip')
+    san_login = SLG.search(data).group('san_login')
+    san_password = SPW.search(data).group('san_password')
+    return san_ip, san_login, san_password
+
+
+def getAPI(san_ip, san_login, san_password, version, tenant=None):
+    if not any((san_ip, san_login, san_password)):
+        san_ip, san_login, san_password = readCinderConf()
+    if tenant and "root" not in tenant:
+        tenant = "/root/{}".format(tenant)
+    return get_api(san_ip,
+                   san_login,
+                   san_password,
+                   version,
+                   tenant=tenant,
+                   secure=True,
+                   immediate_login=True)

--- a/utils/clean_ais.py
+++ b/utils/clean_ais.py
@@ -3,7 +3,6 @@ from __future__ import (print_function, unicode_literals, division,
                         absolute_import)
 
 import argparse
-import io
 import re
 import sys
 import threading
@@ -14,38 +13,8 @@ except ImportError:
     from queue import Queue
 
 from builtins import input
-from dfs_sdk import get_api
 
-IPRE_STR = r'(\d{1,3}\.){3}\d{1,3}'
-IPRE = re.compile(IPRE_STR)
-
-SIP = re.compile(r'san_ip\s+?=\s+?(?P<san_ip>%s)' % IPRE_STR)
-SLG = re.compile(r'san_login\s+?=\s+?(?P<san_login>.*)')
-SPW = re.compile(r'san_password\s+?=\s+?(?P<san_password>.*)')
-
-
-def readCinderConf():
-    data = None
-    with io.open('/etc/cinder/cinder.conf') as f:
-        data = f.read()
-    san_ip = SIP.search(data).group('san_ip')
-    san_login = SLG.search(data).group('san_login')
-    san_password = SPW.search(data).group('san_password')
-    return san_ip, san_login, san_password
-
-
-def getAPI(san_ip, san_login, san_password, version, tenant=None):
-    if not any((san_ip, san_login, san_password)):
-        san_ip, san_login, san_password = readCinderConf()
-    if tenant and "root" not in tenant:
-        tenant = "/root/{}".format(tenant)
-    return get_api(san_ip,
-                   san_login,
-                   san_password,
-                   version,
-                   tenant=tenant,
-                   secure=True,
-                   immediate_login=True)
+from dfs_sdk.scaffold import getAPI
 
 
 def _add_worker(queue, to_delete, api, filters):

--- a/utils/clean_tenants.py
+++ b/utils/clean_tenants.py
@@ -3,42 +3,11 @@ from __future__ import (print_function, unicode_literals, division,
                         absolute_import)
 
 import argparse
-import re
 import sys
 
 from builtins import input
-from dfs_sdk import get_api
 
-IPRE_STR = r'(\d{1,3}\.){3}\d{1,3}'
-IPRE = re.compile(IPRE_STR)
-
-SIP = re.compile(r'san_ip\s+?=\s+?(?P<san_ip>%s)' % IPRE_STR)
-SLG = re.compile(r'san_login\s+?=\s+?(?P<san_login>.*)')
-SPW = re.compile(r'san_password\s+?=\s+?(?P<san_password>.*)')
-
-
-def readCinderConf():
-    data = None
-    with open('/etc/cinder/cinder.conf') as f:
-        data = f.read()
-    san_ip = SIP.search(data).group('san_ip')
-    san_login = SLG.search(data).group('san_login')
-    san_password = SPW.search(data).group('san_password')
-    return san_ip, san_login, san_password
-
-
-def getAPI(san_ip, san_login, san_password, version, tenant=None):
-    if not any((san_ip, san_login, san_password)):
-        san_ip, san_login, san_password = readCinderConf()
-    if tenant and "root" not in tenant:
-        tenant = "/root/{}".format(tenant)
-    return get_api(san_ip,
-                   san_login,
-                   san_password,
-                   version,
-                   tenant=tenant,
-                   secure=True,
-                   immediate_login=True)
+from dfs_sdk.scaffold import getAPI
 
 
 def main(args):

--- a/utils/make_ais.py
+++ b/utils/make_ais.py
@@ -3,8 +3,6 @@ from __future__ import (print_function, unicode_literals, division,
                         absolute_import)
 
 import argparse
-import io
-import re
 import sys
 import threading
 try:
@@ -12,38 +10,7 @@ try:
 except ImportError:
     from queue import Queue
 
-from dfs_sdk import get_api
-
-IPRE_STR = r'(\d{1,3}\.){3}\d{1,3}'
-IPRE = re.compile(IPRE_STR)
-
-SIP = re.compile(r'san_ip\s+?=\s+?(?P<san_ip>%s)' % IPRE_STR)
-SLG = re.compile(r'san_login\s+?=\s+?(?P<san_login>.*)')
-SPW = re.compile(r'san_password\s+?=\s+?(?P<san_password>.*)')
-
-
-def readCinderConf():
-    data = None
-    with io.open('/etc/cinder/cinder.conf') as f:
-        data = f.read()
-    san_ip = SIP.search(data).group('san_ip')
-    san_login = SLG.search(data).group('san_login')
-    san_password = SPW.search(data).group('san_password')
-    return san_ip, san_login, san_password
-
-
-def getAPI(san_ip, san_login, san_password, version, tenant=None):
-    if not any((san_ip, san_login, san_password)):
-        san_ip, san_login, san_password = readCinderConf()
-    if tenant and "root" not in tenant:
-        tenant = "/root/{}".format(tenant)
-    return get_api(san_ip,
-                   san_login,
-                   san_password,
-                   version,
-                   tenant=tenant,
-                   secure=True,
-                   immediate_login=True)
+from dfs_sdk.scaffold import getAPI
 
 
 def _worker(api, queue):

--- a/utils/scaffold.py
+++ b/utils/scaffold.py
@@ -1,0 +1,38 @@
+from __future__ import (print_function, unicode_literals, division,
+                        absolute_import)
+
+import io
+import re
+
+from dfs_sdk import get_api
+
+IPRE_STR = r'(\d{1,3}\.){3}\d{1,3}'
+IPRE = re.compile(IPRE_STR)
+
+SIP = re.compile(r'san_ip\s+?=\s+?(?P<san_ip>%s)' % IPRE_STR)
+SLG = re.compile(r'san_login\s+?=\s+?(?P<san_login>.*)')
+SPW = re.compile(r'san_password\s+?=\s+?(?P<san_password>.*)')
+
+
+def readCinderConf():
+    data = None
+    with io.open('/etc/cinder/cinder.conf') as f:
+        data = f.read()
+    san_ip = SIP.search(data).group('san_ip')
+    san_login = SLG.search(data).group('san_login')
+    san_password = SPW.search(data).group('san_password')
+    return san_ip, san_login, san_password
+
+
+def getAPI(san_ip, san_login, san_password, version, tenant=None):
+    if not any((san_ip, san_login, san_password)):
+        san_ip, san_login, san_password = readCinderConf()
+    if tenant and "root" not in tenant:
+        tenant = "/root/{}".format(tenant)
+    return get_api(san_ip,
+                   san_login,
+                   san_password,
+                   version,
+                   tenant=tenant,
+                   secure=True,
+                   immediate_login=True)


### PR DESCRIPTION
- Moved readCinderConf and getAPI plus supported regexes into
  dfs_sdk.scaffold module since each utility script was using these.
- Scripts can now import "getAPI" from dfs_sdk.scaffold to get access to
  all the previous functionality